### PR TITLE
Update XYAction to fix Mouse-like joystick

### DIFF
--- a/src/actions/ball.c
+++ b/src/actions/ball.c
@@ -187,7 +187,7 @@ static void roll(Mapper* m, BallModifier* b) {
 	
 	if ((fabs(d.x) > 0.001) || (fabs(d.y) >= 0.001)) {
 		wholehaptic_change(&b->whdata, m, d.x, d.y);
-		b->roll_task = m->schedule(m, 2, (MapperScheduleCallback)&roll, b);
+		b->roll_task = m->schedule(m, 20, (MapperScheduleCallback)&roll, b);
 	}
 }
 

--- a/src/actions/xy.c
+++ b/src/actions/xy.c
@@ -126,8 +126,8 @@ static void whole(Action* a, Mapper* m, AxisValue x, AxisValue y, PadStickTrigge
 
 static void change(Action* a, Mapper* m, double dx, double dy, PadStickTrigger what) {
 	XYAction* xy = container_of(a, XYAction, action);
-	if (xy->x->extended.change) xy->x->extended.change(xy->x, m, dx, 0, what);
-	if (xy->y->extended.change) xy->y->extended.change(xy->y, m, 0, dy, what);
+	if (xy->x->axis) xy->x->axis(xy->x, m, clamp(STICK_PAD_MIN, dx, STICK_PAD_MAX), what);
+	if (xy->y->axis) xy->y->axis(xy->y, m, clamp(STICK_PAD_MIN, dy, STICK_PAD_MAX), what);
 }
 
 static Action* compress(Action* _a) {


### PR DESCRIPTION
Fixes the xy->change method that was calling itself instead of axis action.